### PR TITLE
Feat: clusterId별 최신 제보 1개만 반환 기능 추가 및 clusterId와 category로 제보를 조회하는 API 추가

### DIFF
--- a/report/application/report_service.py
+++ b/report/application/report_service.py
@@ -124,3 +124,7 @@ class ReportService:
         report.updated_at = datetime.now(timezone.utc)
 
         return self.repo.update_feedback_counts(report)
+
+
+    def get_reports_by_cluster_and_category(self, cluster_id: str, category: str):
+        return self.repo.find_by_cluster_and_category(cluster_id, category)

--- a/report/domain/repository/report_repo.py
+++ b/report/domain/repository/report_repo.py
@@ -16,7 +16,7 @@ class ReportRepository(ABC):
 
     @abstractmethod
     def find_all(self) -> List[Report]:
-        """전체 제보 조회 (최신순)"""
+        """cluster_id별 제보 조회 (최신순)"""
         raise NotImplementedError
 
     @abstractmethod
@@ -30,3 +30,8 @@ class ReportRepository(ABC):
     ) -> List[Report]:
         """지정 반경 내 제보 리스트 반환"""
         raise NotImplementedError
+
+    @abstractmethod
+    def find_by_cluster_and_category(self, cluster_id: str, category: str) -> List[Report]:
+        raise NotImplementedError
+

--- a/report/infra/repository/postgres_report_repo.py
+++ b/report/infra/repository/postgres_report_repo.py
@@ -123,3 +123,13 @@ class PostgresReportRepository(ReportRepository):
                 )
 
             return hazards
+
+    def find_by_cluster_and_category(self, cluster_id: str, category: str):
+        with SessionLocal() as db:
+            reports = (
+                db.query(ReportDB)
+                .filter(ReportDB.cluster_id == cluster_id, ReportDB.category == category)
+                .order_by(ReportDB.created_at.desc())
+                .all()
+            )
+            return [ReportVO.from_orm(r) for r in reports]

--- a/report/interface/controllers/report_controller.py
+++ b/report/interface/controllers/report_controller.py
@@ -96,3 +96,13 @@ def get_presigned_url(
         return {"upload_url": upload_url, "file_url": file_url}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/filter", response_model=List[Report])
+@inject
+def filter_reports(
+    cluster_id: str = Query(..., description="클러스터 ID"),
+    category: str = Query(..., description="카테고리"),
+    service: ReportService = Depends(Provide["container.report_service"]),
+):
+    return service.get_reports_by_cluster_and_category(cluster_id, category)


### PR DESCRIPTION
지도에서 위험 구역 cluster별 제보 표시를 위해 clusterId별 최신 제보 1개만 반환하는 기능을 추가하고 clusterId와 category로 제보를 조회하는 API를 추가했습니다.